### PR TITLE
throws exception if no project is found

### DIFF
--- a/collect_app/src/main/java/org/bcss/collect/naxa/educational/EducationalMaterialsRemoteSource.java
+++ b/collect_app/src/main/java/org/bcss/collect/naxa/educational/EducationalMaterialsRemoteSource.java
@@ -138,8 +138,7 @@ public class EducationalMaterialsRemoteSource implements BaseRemoteDataSource<Em
                         } else {
                             message = e.getMessage();
                         }
-
-                        SyncLocalSource.getINSTANCE().markAsFailed(EDU_MATERIALS,message);
+                        SyncLocalSource.getINSTANCE().markAsFailed(EDU_MATERIALS, message);
                     }
                 });
 
@@ -165,6 +164,15 @@ public class EducationalMaterialsRemoteSource implements BaseRemoteDataSource<Em
     private Observable<Em> scheduledFormEducational() {
         return ProjectLocalSource.getInstance()
                 .getProjectsMaybe()
+                .map(new Function<List<Project>, List<Project>>() {
+                    @Override
+                    public List<Project> apply(List<Project> projects) throws Exception {
+                        if (projects.isEmpty()) {
+                            throw new RuntimeException("Download project(s) site(s) first");
+                        }
+                        return projects;
+                    }
+                })
                 .toObservable()
                 .flatMapIterable((Function<List<Project>, Iterable<Project>>) projects -> projects)
                 .flatMap((Function<Project, ObservableSource<ArrayList<ScheduleForm>>>) project -> ServiceGenerator.getRxClient().create(ApiInterface.class).getScheduleForms("1", project.getId()))
@@ -191,6 +199,15 @@ public class EducationalMaterialsRemoteSource implements BaseRemoteDataSource<Em
     private Observable<Em> substageFormEducational() {
         return ProjectLocalSource.getInstance()
                 .getProjectsMaybe()
+                .map(new Function<List<Project>, List<Project>>() {
+                    @Override
+                    public List<Project> apply(List<Project> projects) throws Exception {
+                        if (projects.isEmpty()) {
+                            throw new RuntimeException("Download project(s) site(s) first");
+                        }
+                        return projects;
+                    }
+                })
                 .toObservable()
                 .flatMapIterable((Function<List<Project>, Iterable<Project>>) projects -> projects)
                 .flatMap((Function<Project, ObservableSource<ArrayList<Stage>>>) project -> ServiceGenerator.getRxClient().create(ApiInterface.class).getStageSubStage("1", project.getId()))
@@ -221,6 +238,15 @@ public class EducationalMaterialsRemoteSource implements BaseRemoteDataSource<Em
 
         return ProjectLocalSource.getInstance()
                 .getProjectsMaybe()
+                .map(new Function<List<Project>, List<Project>>() {
+                    @Override
+                    public List<Project> apply(List<Project> projects) throws Exception {
+                        if (projects.isEmpty()) {
+                            throw new RuntimeException("Download project(s) site(s) first");
+                        }
+                        return projects;
+                    }
+                })
                 .toObservable()
                 .flatMapIterable((Function<List<Project>, Iterable<Project>>) projects -> projects)
                 .flatMap((Function<Project, ObservableSource<ArrayList<GeneralForm>>>) project -> ServiceGenerator.getRxClient().create(ApiInterface.class).getGeneralFormsObservable("1", project.getId()))


### PR DESCRIPTION
Closes #59 

#### What has been done to verify that this works as intended?
I tired downloading educational material before projects and sites

#### Why is this the best possible solution? Were any other approaches considered?
This can be done better, first instance being  ```ProjectLocalSource.getInstance().getProjectsMaybe()``` called multiple times, in the same Rx Chain

Another instance, 
```               return ProjectLocalSource.getInstance()
                .getProjectsMaybe()
                .map(new Function<List<Project>, List<Project>>() {
                    @Override
                    public List<Project> apply(List<Project> projects) throws Exception {
                        if (projects.isEmpty()) {
                            throw new RuntimeException("Download project(s) site(s) first");
                        }
                        return projects;
                    }
                })
                    }
```

I am throwing a run time exception but we could query the server if our local source is empty

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

User will see a new message, when education materials are downloaded before downloading projects and sites first

![Screenshot_1552368112](https://user-images.githubusercontent.com/11831955/54176658-d1bc6700-44b7-11e9-8399-51934c083df5.png)


#### Do we need any specific form for testing your changes? If so, please attach one.
Nope
