### PR TITLE
Stops instance-sync-task (#494)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -59,6 +59,7 @@ import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColum
 public class InstanceSyncTask extends AsyncTask<Void, String, String> {
 
     private static int counter;
+    private boolean shouldExit = true;
 
     private String currentStatus = "";
     private DiskSyncListener diskSyncListener;
@@ -73,6 +74,11 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
 
     @Override
     protected String doInBackground(Void... params) {
+        if (shouldExit) {
+            Timber.i("%s called a exit on %s", R.string.app_name, this.getClass().getSimpleName());
+            currentStatus = "";
+            return currentStatus;
+        }
         int instance = ++counter;
         Timber.i("[%d] doInBackground begins!", instance);
 


### PR DESCRIPTION
Closes #494 

<!-- 
Thank you for contributing to FieldSight!

-->

#### What has been done to verify that this works as intended?
- Opened Edit and upload screens and it did not crash

#### Why is this the best possible solution? Were any other approaches considered?
- We do not use InstanceSyncTask but we would like to extened ODKs screens for upload and edit. 
So, I just exited (Killed) that task.

- We could make changes in how InstanceSyncTask work, so that it does not crash or We could remove all the places that InstanceSyncTask is being called but this would require large amount of unneeded changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
Yes, Instructions are on #494 

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
